### PR TITLE
Split config file management, use archive resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 2.0.0-unreleased
+- breaking: split the management of the config file to a define, so more than one user's config can be managed
+- breaking: no longer provide $dependencies parameter
+- major: add a dependency on puppet/archive for downloading and extracting the ngrok zip, supports checksums
+
 ## 1.1.0
 - bugfix: ensure config folder exists
 - meta: add tests

--- a/README.md
+++ b/README.md
@@ -2,31 +2,34 @@
 
 An opinionated Puppet Module to install and manage [Ngrok](https://ngrok.com/).
 
-puppet-ngrok is available on the
-[Puppet Forge](https://forge.puppetlabs.com/thekevjames/ngrok).
+puppet-ngrok is available on the [Puppet Forge](https://forge.puppetlabs.com/thekevjames/ngrok).
 
 ## Usage
 
-Simply
+To install ngrok, include the main `ngrok` class:
 
 ```puppet
-class { '::ngrok':
-  home  => '/home/kevin',
-  token => hiera('ngrok', '[unsecretify me!]'),
+include '::ngrok'
+```
+
+### Configuration
+
+If you'd like to configure one or more user's ngrok tokens, you can use the `ngrok::config` define:
+
+```puppet
+ngrok::config { '/home/someuser':
+  token => 'some-secret-token';
 }
 ```
 
-to make sure ngrok is installed.
+The name of the resource should be the path to a user's home directory.
 
-## Configuration
+## Parameters
 
-In addition to the above value set for `ngrok`, you can also use
-hiera to override the following defaults:
+You can also provide values for the following parameters:
 
 ```yaml
-ngrok::dependencies:
-  - curl
-  - unzip
-
-ngrok::url: https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip
+ngrok::url: https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip # An absolute URL for where to download the ngrok zip file
+ngrok::install_path: /opt # The install path to use; ngrok will be installed to <path>/ngrok, as well as symlinked into /usr/local/bin
+ngrok::archive_arguments: {} # An optional hash of arguments that will passed to the archive {} resource, e.g. checksum (see https://forge.puppet.com/puppet/archive#usage)
 ```

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,0 +1,25 @@
+# Pass home dir as namevar to create a ngrok configuration
+define ngrok::config(
+  Optional[String] $token = ''
+) {  # lint:ignore:parameter_defaults
+  validate_absolute_path($name)
+
+  ensure_resource(file, "${name}/.config", { ensure => 'directory' })
+
+  file { "${name}/.config/ngrok":
+    ensure  => 'directory',
+    require => File["${name}/.config"],
+  } ->
+  file { "${name}/.config/ngrok/config.yml":
+    ensure  => present,
+    content => template('ngrok/config.erb'),
+    mode    => '0644',
+  }
+
+  # ngrok does not support XDG. ngrok should support XDG.
+  file { "${name}/.ngrok2": ensure => 'directory' } ->
+  file { "${name}/.ngrok2/ngrok.yml":
+    ensure => link,
+    target => "${name}/.config/ngrok/config.yml",
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,11 @@
 # Install and configure ngrok.
-class ngrok($dependencies, $url, $home, $token = '') {  # lint:ignore:parameter_defaults
+class ngrok(
+  Array $dependencies,
+  String $url,
+  String $home,
+  Optional[String] $token = ''
+) {  # lint:ignore:parameter_defaults
+  validate_absolute_path($home)
 
   ensure_resource(file, "${home}/.config", { ensure => directory })
 

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,8 @@
   "project_page": "https://github.com/TheKevJames/puppet-ngrok",
   "issues_url": "https://github.com/TheKevJames/puppet-ngrok/issues",
   "dependencies": [
-    {"name": "puppetlabs/stdlib", "version_requirement": ">= 4.2.0 < 5.0.0"}
+    {"name": "puppetlabs/stdlib", "version_requirement": ">= 4.2.0 < 5.0.0"},
+    {"name": "puppet/archive", "version_requirement": ">= 1.3.0"}
   ],
   "data_provider": "hiera",
   "operatingsystem_support": [

--- a/templates/config.erb
+++ b/templates/config.erb
@@ -1,1 +1,1 @@
-authtoken: <%= scope['ngrok::token'] %>
+authtoken: <%= @token %>

--- a/tests/config.pp
+++ b/tests/config.pp
@@ -1,0 +1,3 @@
+ngrok::config { '/home/ubuntu':
+  token => 'test-token';
+}

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -1,4 +1,2 @@
-class { '::ngrok':
-    home  => '/home/ubuntu',
-    token => 'test-token',
+class { '::ngrok':;
 }


### PR DESCRIPTION
Adds a dependency on `puppet-archive`, which provides a resource for downloading and extracting archive files. (This means we don't need to define the download and extract operation ourselves, and we get features like checksumming for 'free').

Also splits the config file management out to a separate `ngrok::config` resource.

Both are breaking changes, so shouldn't be merged into the 1.0 branch.

Fixes #5